### PR TITLE
Wait for target

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,4 +42,8 @@ Example:
 
 `python3 wait_for_target.py --url <URL of moment listing> --target <target_price>`
 
+optional:
+
+`--interval polling interval that defaults to 10s`
+
 When the moment's lowest price falls below the target price it will make a noise and open a tab for the listing.

--- a/README.md
+++ b/README.md
@@ -4,13 +4,13 @@ This script is meant to show NBA Top Shot listings that should be considered to 
 
 ## Usage:
 
-### To Analyze a Listing:
-
 ```
 pip install -r requirements.txt
-
-python3 analyze.py --url <URL of moment listing>
 ```
+
+### To Analyze a Listing:
+
+`python3 analyze.py --url <URL of moment listing>`
 
 optional:
 
@@ -37,3 +37,9 @@ Example:
 2. In the file, add a url to a listing per line
 3. Run `python3 prices.py`
 4. Inspect output.txt. Each line will contain the lowest price for the corresponding line in input.txt
+
+### To monitor a listing
+
+`python3 wait_for_target.py --url <URL of moment listing> --target <target_price>`
+
+When the moment's lowest price falls below the target price it will make a noise and open a tab for the listing.

--- a/analyze_listing.py
+++ b/analyze_listing.py
@@ -1,4 +1,5 @@
 import csv
+import sys
 
 from listings import get_all_listings_from_url
 

--- a/listings.py
+++ b/listings.py
@@ -1,11 +1,28 @@
+import datetime
 import json
 import requests
 
 from bs4 import BeautifulSoup
 
 
-def get_lowest_price_from_url(url):
-    page = requests.get(url.strip())
+def get_listing_page(url):
+    if not str.startswith(url, "https://www.nbatopshot.com/listings/p2p/"):
+        raise ValueError("User passed malformed URL")
+
+    return requests.get(url.strip())
+
+def print_listing_details(page):
+    soup = BeautifulSoup(page.content, 'html.parser')
+    script = soup.find('script', id='__NEXT_DATA__')
+    json_object = json.loads(script.contents[0])
+    moment = json_object['props']['pageProps']['moment']
+    play = moment['play']
+    moments = moment['momentListings']
+    title = soup.title
+    price = str(title).split("-")[0].split("$")[1].strip()
+    print(play['stats']['playerName'] + " " + play['stats']['playCategory'] + " - " + moment['set']['flowName'] + " " + str(moment['set']['flowSeriesNumber']))
+
+def get_lowest_price_from_url(page):
     soup = BeautifulSoup(page.content, 'html.parser')
     script = soup.find('script', id='__NEXT_DATA__')
     json_object = json.loads(script.contents[0])
@@ -17,9 +34,25 @@ def get_lowest_price_from_url(url):
     return price
 	
 def get_all_listings_from_url(url):
+    if not str.startswith(url, "https://www.nbatopshot.com/listings/p2p/"):
+        raise ValueError("User passed malformed URL")
+
     page = requests.get(url)
     soup = BeautifulSoup(page.content, 'html.parser')
     script = soup.find('script', id='__NEXT_DATA__')
     json_object = json.loads(script.contents[0])
     moment = json_object['props']['pageProps']['moment']
     return moment
+
+def price_lower_than_target(url, target):
+    if not str.startswith(url, "https://www.nbatopshot.com/listings/p2p/"):
+        raise ValueError("User passed malformed URL")
+    if target < 0:
+        raise ValueError("User passed invalid maxprice")
+
+    page = get_listing_page(url)
+    price = get_lowest_price_from_url(page)
+    if not (float(price) < target):
+        #print("{} is not less than {}".format(price, target))
+        print("Latest price: {}          at {}".format(price, datetime.datetime.now().strftime("%b %d %Y %I:%M:%S %p")), end='\r')
+    return float(price) < target

--- a/prices.py
+++ b/prices.py
@@ -1,4 +1,4 @@
-from listings import get_lowest_price_from_url
+from listings import get_lowest_price_from_url, get_listing_page
 from utils import time_func
 
 
@@ -6,7 +6,9 @@ def write_prices():
     with open("input.txt") as infile, open("output.txt", "w") as outfile:
         lines = infile.readlines()
         for line in lines:
-            price = get_lowest_price_from_url(line)		
+		    page = get_listing_page(line)
+            price = get_lowest_price_from_url(page)
             outfile.write(price + "\n")
+            print('.', end='')
 
 time_func("fetch the list of prices", write_prices)

--- a/prices.py
+++ b/prices.py
@@ -6,7 +6,7 @@ def write_prices():
     with open("input.txt") as infile, open("output.txt", "w") as outfile:
         lines = infile.readlines()
         for line in lines:
-		    page = get_listing_page(line)
+            page = get_listing_page(line)
             price = get_lowest_price_from_url(page)
             outfile.write(price + "\n")
             print('.', end='')

--- a/wait_for_target.py
+++ b/wait_for_target.py
@@ -1,5 +1,5 @@
 import argparse
-from os import system
+from os import system, name
 import time
 import webbrowser
 import winsound
@@ -15,7 +15,12 @@ parser.add_argument("-t", "--target", type=float, help="Enter a target price", r
 
 args = parser.parse_args()
 
-_ = system('cls')
+# for windows
+if name == 'nt':
+    _ = system('cls')
+# for mac and linux(here, os.name is 'posix')
+else:
+    _ = system('clear')
 
 
 page = get_listing_page(args.url)
@@ -31,5 +36,7 @@ while not found:
     time.sleep(10)
 
 if found:
-    winsound.PlaySound("SystemExit", winsound.SND_ALIAS)
+    if name == 'nt':
+        winsound.PlaySound("SystemExit", winsound.SND_ALIAS)
+	# TODO else for linux/mac (find a library or whatever)
     webbrowser.open_new_tab(args.url)

--- a/wait_for_target.py
+++ b/wait_for_target.py
@@ -2,7 +2,8 @@ import argparse
 from os import system, name
 import time
 import webbrowser
-import winsound
+if name == 'nt':
+    import winsound
 
 from listings import get_lowest_price_from_url, price_lower_than_target, print_listing_details, get_listing_page
 

--- a/wait_for_target.py
+++ b/wait_for_target.py
@@ -1,0 +1,35 @@
+import argparse
+from os import system
+import time
+import webbrowser
+import winsound
+
+from listings import get_lowest_price_from_url, price_lower_than_target, print_listing_details, get_listing_page
+
+parser = argparse.ArgumentParser(description="Wait for a topshot price")
+
+# if you want to make this implicit/positional later, you can add required=True and remove the "-u" and the "--" in from of url
+parser.add_argument("-u", "--url", type=str, help="URL of a moment (required)", required=True)
+
+parser.add_argument("-t", "--target", type=float, help="Enter a target price", required=True)
+
+args = parser.parse_args()
+
+_ = system('cls')
+
+
+page = get_listing_page(args.url)
+print("Target Price: {}          ".format("{:.2f}".format(args.target)), end='')
+print_listing_details(page)
+
+found = False
+while not found:
+    try:
+        found = price_lower_than_target(args.url, args.target)
+    except:
+        pass
+    time.sleep(10)
+
+if found:
+    winsound.PlaySound("SystemExit", winsound.SND_ALIAS)
+    webbrowser.open_new_tab(args.url)

--- a/wait_for_target.py
+++ b/wait_for_target.py
@@ -13,6 +13,8 @@ parser.add_argument("-u", "--url", type=str, help="URL of a moment (required)", 
 
 parser.add_argument("-t", "--target", type=float, help="Enter a target price", required=True)
 
+parser.add_argument("-i", "--interval", type=int, default=10, help="Polling interval in seconds", required=False)
+
 args = parser.parse_args()
 
 # for windows
@@ -27,13 +29,18 @@ page = get_listing_page(args.url)
 print("Target Price: {}          ".format("{:.2f}".format(args.target)), end='')
 print_listing_details(page)
 
+if args.interval < 1:
+    interval = 10
+else:
+    interval = args.interval
+
 found = False
 while not found:
     try:
         found = price_lower_than_target(args.url, args.target)
     except:
         pass
-    time.sleep(10)
+    time.sleep(args.interval)
 
 if found:
     if name == 'nt':


### PR DESCRIPTION
- Fix an error trying to do sys.exit without sys imported
- Add get_listing_page so we can re-use the page without having to call requests.get again if we don't need to
- Add a page to print a listings details (player name, type of play, set)
- Add price_lower_than_target which is used to wait for a price to drop below a set value
- Error handling for user-inputted urls and ints
- Wrote wait_for_target.py to actually run the script waiting for the target price